### PR TITLE
No need to center crop the mask at testing stage. 

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -141,7 +141,8 @@ class Dataset(torch.utils.data.Dataset):
         # test mode: load mask non random
         if mask_type == 6:
             mask = imread(self.mask_data[index])
-            mask = self.resize(mask, imgh, imgw)
+            mask = self.resize(mask, imgh, imgw, centerCrop=False)
+            mask = rgb2gray(mask)
             mask = (mask > 0).astype(np.uint8) * 255
             return mask
 
@@ -150,10 +151,10 @@ class Dataset(torch.utils.data.Dataset):
         img_t = F.to_tensor(img).float()
         return img_t
 
-    def resize(self, img, height, width):
+    def resize(self, img, height, width, centerCrop=True):
         imgh, imgw = img.shape[0:2]
 
-        if imgh != imgw:
+        if centerCrop and imgh != imgw:
             # center crop
             side = np.minimum(imgh, imgw)
             j = (imgh - side) // 2


### PR DESCRIPTION
In the testing phase, input image could be any size, e.g. `[640,320]`.
In the origin codes, the input mask of size `[640,320]` will be center cropped into [320,320] first and then resize to [640,320] which will cause the mask distortion.