### PR TITLE
Update dataset.py

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -172,7 +172,9 @@ class Dataset(torch.utils.data.Dataset):
         # flist: image file path, image directory path, text file flist path
         if isinstance(flist, str):
             if os.path.isdir(flist):
-                return list(glob.glob(flist + '/*.jpg')) + list(glob.glob(flist + '/*.png'))
+                flist = list(glob.glob(flist + '/*.jpg')) + list(glob.glob(flist + '/*.png'))
+                flist.sort()
+                return flist
 
             if os.path.isfile(flist):
                 try:


### PR DESCRIPTION
In test phase, the input images under directory should be sorted as in `flist.py`.
In the original codes, the `.jpg` images will be always ordered ahead of `.png` images. Images should be ordered by names other than `ext`. 
e.g. If flist is directory, input images are `01.png`, `02.png`, `03.jpg`, input masks are  `01.png`, `02.png`, `03.png`. Then the results will turn into a whole mess.