### PR TITLE
Fix a training model selection bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,7 +96,8 @@ def load_config(mode=None):
     # train mode
     if mode == 1:
         config.MODE = 1
-        config.MODEL = args.model if args.model is not None else 1
+        if args.model:
+            config.MODEL = args.model 
 
     # test mode
     elif mode == 2:


### PR DESCRIPTION
Fix a bug that in training phase, when `MODEL=2` in `config.yml` and no `--model` arg it will turn into training model 3 instead of 2.