### PR TITLE
Fixed 3 issues of type: PYTHON_E251 throughout 2 files in repo.

### DIFF
--- a/src/edge_connect.py
+++ b/src/edge_connect.py
@@ -388,7 +388,7 @@ class EdgeConnect():
             self.postprocess(edges),
             self.postprocess(outputs),
             self.postprocess(outputs_merged), 
-            img_per_row = image_per_row
+            img_per_row=image_per_row
         )
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -143,7 +143,7 @@ class EdgeModel(BaseModel):
         outputs = self.generator(inputs)                                    # in: [grayscale(1) + edge(1) + mask(1)]
         return outputs
 
-    def backward(self, gen_loss = None, dis_loss = None):
+    def backward(self, gen_loss=None, dis_loss=None):
         if dis_loss is not None:
             dis_loss.backward()
         self.dis_optimizer.step()
@@ -255,7 +255,7 @@ class InpaintingModel(BaseModel):
         outputs = self.generator(inputs)                                    # in: [rgb(3) + edge(1)]
         return outputs
 
-    def backward(self, gen_loss = None, dis_loss = None):
+    def backward(self, gen_loss=None, dis_loss=None):
         dis_loss.backward()
         self.dis_optimizer.step()
 


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.