### PR TITLE
Fixed 12 issues of type: PYTHON_W291 throughout 6 files in repo.

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ def main(mode=None):
 
 
 def load_config(mode=None):
-    r"""loads model config 
+    r"""loads model config
 
     Args:
         mode (int): 1: train, 2: test, 3: eval, reads from config file if not specified
@@ -102,7 +102,7 @@ def load_config(mode=None):
     if mode == 1:
         config.MODE = 1
         if args.model:
-            config.MODEL = args.model 
+            config.MODEL = args.model
 
     # test mode
     elif mode == 2:

--- a/scripts/fid_score.py
+++ b/scripts/fid_score.py
@@ -112,10 +112,10 @@ def calculate_frechet_distance(mu1, sigma1, mu2, sigma2, eps=1e-6):
     -- mu1   : Numpy array containing the activations of a layer of the
                inception net (like returned by the function 'get_predictions')
                for generated samples.
-    -- mu2   : The sample mean over activations, precalculated on an 
+    -- mu2   : The sample mean over activations, precalculated on an
                representive data set.
     -- sigma1: The covariance matrix over activations for generated samples.
-    -- sigma2: The covariance matrix over activations, precalculated on an 
+    -- sigma2: The covariance matrix over activations, precalculated on an
                representive data set.
     Returns:
     --   : The Frechet Distance.

--- a/scripts/inception.py
+++ b/scripts/inception.py
@@ -108,11 +108,11 @@ class InceptionV3(nn.Module):
         Parameters
         ----------
         inp : torch.autograd.Variable
-            Input tensor of shape Bx3xHxW. Values are expected to be in 
+            Input tensor of shape Bx3xHxW. Values are expected to be in
             range (0, 1)
         Returns
         -------
-        List of torch.autograd.Variable, corresponding to the selected output 
+        List of torch.autograd.Variable, corresponding to the selected output
         block, sorted ascending by index
         """
         outp = []

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -85,11 +85,11 @@ class Dataset(torch.utils.data.Dataset):
     def load_edge(self, img, index, mask):
         sigma = self.sigma
 
-        # in test mode images are masked (with masked regions), 
+        # in test mode images are masked (with masked regions),
         # using 'mask' parameter prevents canny to detect edges for the masked regions
         mask = None if self.training else (1 - mask / 255).astype(np.bool)
 
-        # canny 
+        # canny
         if self.edge == 1:
             # no edge
             if sigma == -1:

--- a/src/edge_connect.py
+++ b/src/edge_connect.py
@@ -343,7 +343,7 @@ class EdgeConnect():
     def sample(self, it=None):
         # do not sample when validation set is empty
         if len(self.val_dataset) == 0:
-            return 
+            return
 
         self.edge_model.eval()
         self.inpaint_model.eval()
@@ -387,7 +387,7 @@ class EdgeConnect():
             self.postprocess(inputs),
             self.postprocess(edges),
             self.postprocess(outputs),
-            self.postprocess(outputs_merged), 
+            self.postprocess(outputs_merged),
             img_per_row = image_per_row
         )
 

--- a/src/models.py
+++ b/src/models.py
@@ -26,7 +26,7 @@ class BaseModel(nn.Module):
             
             if torch.cuda.is_available():
                 data = torch.load(self.gen_weights_path)
-            else: 
+            else:
                 data = torch.load(self.gen_weights_path, map_location=lambda storage, loc: storage)
 
             self.generator.load_state_dict(data['generator'])
@@ -120,7 +120,7 @@ class EdgeModel(BaseModel):
 
 
         # generator feature matching loss
-        gen_fm_loss = 0 
+        gen_fm_loss = 0
         for i in range(len(dis_real_feat)):
             gen_fm_loss += self.l1_loss(gen_fake_feat[i], dis_real_feat[i].detach())
         gen_fm_loss = gen_fm_loss * self.config.FM_LOSS_WEIGHT


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.