### PR TITLE
Fixed 11 issues of type: PYTHON_W293 throughout 5 files in repo.

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def load_config(mode=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('--path', '--checkpoints', type=str, default='./checkpoints', help='model checkpoints path (default: ./checkpoints)')
     parser.add_argument('--model', type=int, choices=[1, 2, 3, 4], help='1: edge model, 2: inpaint model, 3: edge-inpaint model, 4: joint model')
-    
+
     # test mode
     if mode == 2:
         parser.add_argument('--input', type=str, help='path to the input images directory or an input image')

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ class Config(dict):
             self._yaml = f.read()
             self._dict = yaml.load(self._yaml)
             self._dict['PATH'] = os.path.dirname(config_path)
- 
+
     def __getattr__(self, name):
         if self._dict.get(name) is not None:
             return self._dict[name]

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -52,24 +52,24 @@ class Dataset(torch.utils.data.Dataset):
     def load_item(self, index):
 
         size = self.input_size
-        
+
         # load image
         img = imread(self.data[index])
 
         # gray to rgb
         if len(img.shape) < 3:
             img = gray2rgb(img)
-        
+
         # resize/crop if needed
         if size != 0:
             img = self.resize(img, size, size)
 
         # create grayscale image
         img_gray = rgb2gray(img)
-        
+
         # load mask
         mask = self.load_mask(img, index)
-        
+
         # load edge
         edge = self.load_edge(img_gray, index, mask)
 
@@ -94,11 +94,11 @@ class Dataset(torch.utils.data.Dataset):
             # no edge
             if sigma == -1:
                 return np.zeros(img.shape).astype(np.float)
-            
+
             # random sigma
             if sigma == 0:
                 sigma = random.randint(1, 4)
-                
+
             return canny(img, sigma=sigma, mask=mask).astype(np.float)
 
         # external
@@ -185,7 +185,7 @@ class Dataset(torch.utils.data.Dataset):
                     return np.genfromtxt(flist, dtype=np.str, encoding='utf-8')
                 except:
                     return [flist]
-        
+
         return []
 
     def create_iterator(self, batch_size):

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -39,7 +39,7 @@ class PSNR(nn.Module):
 
     def __call__(self, a, b):
         mse = torch.mean((a.float() - b.float()) ** 2)
-    
+
         if mse == 0:
             return torch.tensor(0)
 

--- a/src/models.py
+++ b/src/models.py
@@ -23,7 +23,7 @@ class BaseModel(nn.Module):
     def load(self):
         if os.path.exists(self.gen_weights_path):
             print('Loading %s generator...' % self.name)
-            
+
             if torch.cuda.is_available():
                 data = torch.load(self.gen_weights_path)
             else: 


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.