### PR TITLE
Fixed 4 issues of type: PYTHON_F401 throughout 4 files in repo.

### DIFF
--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 import argparse
 import matplotlib.pyplot as plt

--- a/src/edge_connect.py
+++ b/src/edge_connect.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 import torch
-import torch.nn as nn
 from torch.utils.data import DataLoader
 from .dataset import Dataset
 from .models import EdgeModel, InpaintingModel

--- a/src/models.py
+++ b/src/models.py
@@ -1,11 +1,8 @@
 import os
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from torch.utils.data import DataLoader
 from .networks import InpaintGenerator, EdgeGenerator, Discriminator
-from .dataset import Dataset
 from .loss import AdversarialLoss, PerceptualLoss, StyleLoss
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,4 @@
 import os
-import cv2
 import sys
 import time
 import random


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        